### PR TITLE
Add year to the title and heading of individual yearly pages

### DIFF
--- a/template/index.html
+++ b/template/index.html
@@ -1,50 +1,44 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta
-      name="viewport"
-      content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
-    />
-    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-    <link rel="stylesheet" href="style.css" />
-    <title>Koodiklinikan palkkakysely, {{ year }}</title>
-  </head>
-  <body>
-    <h1>Koodiklinikan palkkakysely, {{ year }}</h1>
-    <h2>Tunnusluvut</h2>
-    <ul>
-      <li><i>n</i> = {{ df|length }}</li>
-      {% with num_kk = df[pd.to_numeric(df['Kuukausipalkka'],
-      errors='coerce').notnull()]['Kuukausipalkka'] %}
-      <li>Keskimääräinen kuukausipalkka = {{ num_kk.mean()|round(0) }} €</li>
-      <li>Mediaanikuukausipalkka = {{ num_kk.median()|round(0) }} €</li>
-      {% endwith %} {% with num_v = df[pd.to_numeric(df['Vuositulot'],
-      errors='coerce').notnull()]['Vuositulot'] %}
-      <li>Keskimääräiset vuositulot = {{ num_v.mean()|round(0) }} €</li>
-      <li>Mediaanivuositulot = {{ num_v.median()|round(0) }} €</li>
-      {% endwith %}
-    </ul>
-    <h2>Työkalut</h2>
-    <ul>
-      <li><a href="charts.html">Kaaviot</a></li>
-      <li><a href="profiling_report.html">Lähdedatan analyysi</a></li>
-      <li>
-        <a
-          href="/palkkakysely/analysaattori/?url=/palkkakysely/{{ year }}/data.json"
-          >Pivot-työkalu</a
-        >
-      </li>
-    </ul>
-    <h2>Data</h2>
-    <ul>
-      <li><a href="data.csv">Lähdedata (CSV)</a></li>
-      <li><a href="data.html">Lähdedata (HTML)</a></li>
-      <li><a href="data.json">Lähdedata (JSON)</a></li>
-      <li><a href="data.xlsx">Lähdedata (XLSX)</a></li>
-      <li><a href="raw.tsv">Raakadata (TSV)</a></li>
-      <li><a href="raw.xlsx">Raakadata (XLSX)</a></li>
-    </ul>
-    <footer>Generoitu {{ date }}</footer>
-  </body>
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <link rel="stylesheet" href="style.css">
+    <title>Koodiklinikan palkkakysely, {{year}}</title>
+</head>
+<body>
+<h1>Koodiklinikan palkkakysely, {{year}}</h1>
+<h2>Tunnusluvut</h2>
+<ul>
+    <li><i>n</i> = {{ df|length }}</li>
+    {% with num_kk = df[pd.to_numeric(df['Kuukausipalkka'], errors='coerce').notnull()]['Kuukausipalkka'] %}
+        <li>Keskimääräinen kuukausipalkka = {{ num_kk.mean()|round(0) }} €</li>
+        <li>Mediaanikuukausipalkka = {{ num_kk.median()|round(0) }} €</li>
+    {% endwith %}
+    {% with num_v = df[pd.to_numeric(df['Vuositulot'], errors='coerce').notnull()]['Vuositulot'] %}
+        <li>Keskimääräiset vuositulot = {{ num_v.mean()|round(0) }} €</li>
+        <li>Mediaanivuositulot = {{ num_v.median()|round(0) }} €</li>
+    {% endwith %}
+</ul>
+<h2>Työkalut</h2>
+<ul>
+    <li><a href="charts.html">Kaaviot</a></li>
+    <li><a href="profiling_report.html">Lähdedatan analyysi</a></li>
+    <li><a href="/palkkakysely/analysaattori/?url=/palkkakysely/{{ year }}/data.json">Pivot-työkalu</a></li>
+</ul>
+<h2>Data</h2>
+<ul>
+    <li><a href="data.csv">Lähdedata (CSV)</a></li>
+    <li><a href="data.html">Lähdedata (HTML)</a></li>
+    <li><a href="data.json">Lähdedata (JSON)</a></li>
+    <li><a href="data.xlsx">Lähdedata (XLSX)</a></li>
+    <li><a href="raw.tsv">Raakadata (TSV)</a></li>
+    <li><a href="raw.xlsx">Raakadata (XLSX)</a></li>
+</ul>
+<footer>
+    Generoitu {{ date }}
+</footer>
+</body>
 </html>

--- a/template/index.html
+++ b/template/index.html
@@ -1,44 +1,50 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport"
-          content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <link rel="stylesheet" href="style.css">
-    <title>Koodiklinikan palkkakysely</title>
-</head>
-<body>
-<h1>Koodiklinikan palkkakysely</h1>
-<h2>Tunnusluvut</h2>
-<ul>
-    <li><i>n</i> = {{ df|length }}</li>
-    {% with num_kk = df[pd.to_numeric(df['Kuukausipalkka'], errors='coerce').notnull()]['Kuukausipalkka'] %}
-        <li>Keskimääräinen kuukausipalkka = {{ num_kk.mean()|round(0) }} €</li>
-        <li>Mediaanikuukausipalkka = {{ num_kk.median()|round(0) }} €</li>
-    {% endwith %}
-    {% with num_v = df[pd.to_numeric(df['Vuositulot'], errors='coerce').notnull()]['Vuositulot'] %}
-        <li>Keskimääräiset vuositulot = {{ num_v.mean()|round(0) }} €</li>
-        <li>Mediaanivuositulot = {{ num_v.median()|round(0) }} €</li>
-    {% endwith %}
-</ul>
-<h2>Työkalut</h2>
-<ul>
-    <li><a href="charts.html">Kaaviot</a></li>
-    <li><a href="profiling_report.html">Lähdedatan analyysi</a></li>
-    <li><a href="/palkkakysely/analysaattori/?url=/palkkakysely/{{ year }}/data.json">Pivot-työkalu</a></li>
-</ul>
-<h2>Data</h2>
-<ul>
-    <li><a href="data.csv">Lähdedata (CSV)</a></li>
-    <li><a href="data.html">Lähdedata (HTML)</a></li>
-    <li><a href="data.json">Lähdedata (JSON)</a></li>
-    <li><a href="data.xlsx">Lähdedata (XLSX)</a></li>
-    <li><a href="raw.tsv">Raakadata (TSV)</a></li>
-    <li><a href="raw.xlsx">Raakadata (XLSX)</a></li>
-</ul>
-<footer>
-    Generoitu {{ date }}
-</footer>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
+    />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <link rel="stylesheet" href="style.css" />
+    <title>Koodiklinikan palkkakysely, {{ year }}</title>
+  </head>
+  <body>
+    <h1>Koodiklinikan palkkakysely, {{ year }}</h1>
+    <h2>Tunnusluvut</h2>
+    <ul>
+      <li><i>n</i> = {{ df|length }}</li>
+      {% with num_kk = df[pd.to_numeric(df['Kuukausipalkka'],
+      errors='coerce').notnull()]['Kuukausipalkka'] %}
+      <li>Keskimääräinen kuukausipalkka = {{ num_kk.mean()|round(0) }} €</li>
+      <li>Mediaanikuukausipalkka = {{ num_kk.median()|round(0) }} €</li>
+      {% endwith %} {% with num_v = df[pd.to_numeric(df['Vuositulot'],
+      errors='coerce').notnull()]['Vuositulot'] %}
+      <li>Keskimääräiset vuositulot = {{ num_v.mean()|round(0) }} €</li>
+      <li>Mediaanivuositulot = {{ num_v.median()|round(0) }} €</li>
+      {% endwith %}
+    </ul>
+    <h2>Työkalut</h2>
+    <ul>
+      <li><a href="charts.html">Kaaviot</a></li>
+      <li><a href="profiling_report.html">Lähdedatan analyysi</a></li>
+      <li>
+        <a
+          href="/palkkakysely/analysaattori/?url=/palkkakysely/{{ year }}/data.json"
+          >Pivot-työkalu</a
+        >
+      </li>
+    </ul>
+    <h2>Data</h2>
+    <ul>
+      <li><a href="data.csv">Lähdedata (CSV)</a></li>
+      <li><a href="data.html">Lähdedata (HTML)</a></li>
+      <li><a href="data.json">Lähdedata (JSON)</a></li>
+      <li><a href="data.xlsx">Lähdedata (XLSX)</a></li>
+      <li><a href="raw.tsv">Raakadata (TSV)</a></li>
+      <li><a href="raw.xlsx">Raakadata (XLSX)</a></li>
+    </ul>
+    <footer>Generoitu {{ date }}</footer>
+  </body>
 </html>


### PR DESCRIPTION
Make it clearer to the reader which year's results they are reading

Before:
<img width="741" alt="palkkakysely_ilman_vuosilukua" src="https://user-images.githubusercontent.com/1909996/192486564-7dca5225-3d03-48c2-b2e1-a02fc8550ca8.png">

After:
<img width="768" alt="palkkakysely_vuosiluvulla" src="https://user-images.githubusercontent.com/1909996/192486616-7cd2030e-b697-4fbd-a405-d05d3635a27a.png">

